### PR TITLE
Add PouchDB/CouchDB sync and basic course flows

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,4 @@
+COUCHDB_URL=localhost:5984
+COUCHDB_USER=prince
+COUCHDB_PASS=iranzi123
+JWT_SECRET=changeme

--- a/backend/controllers/courseController.js
+++ b/backend/controllers/courseController.js
@@ -1,0 +1,45 @@
+const Course = require('../models/Course');
+
+exports.createCourse = async (req, res) => {
+  try {
+    const data = await Course.create({
+      title: req.body.title,
+      description: req.body.description,
+      instructorId: req.user.id
+    });
+    res.status(201).json(data);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Failed to create course' });
+  }
+};
+
+exports.getApproved = async (req, res) => {
+  try {
+    const docs = await Course.findByStatus('approved');
+    res.json(docs);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Failed to fetch courses' });
+  }
+};
+
+exports.getPending = async (req, res) => {
+  try {
+    const docs = await Course.findByStatus('pending');
+    res.json(docs);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Failed to fetch pending courses' });
+  }
+};
+
+exports.approve = async (req, res) => {
+  try {
+    const course = await Course.updateStatus(req.params.id, 'approved');
+    res.json(course);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ message: 'Failed to approve course' });
+  }
+};

--- a/backend/db.js
+++ b/backend/db.js
@@ -29,11 +29,12 @@ nanoInstance.db.list()
     console.error('CouchDB connection error:', err);
   });
 
-// Get users database
+// Get databases
 const usersDb = nanoInstance.db.use('users');
+const coursesDb = nanoInstance.db.use('courses');
 
-// Ensure users database exists
-const ensureUsersDb = async () => {
+// Ensure databases exist
+const ensureDbs = async () => {
   try {
     await usersDb.info();
     console.log('Users database exists and is accessible');
@@ -46,9 +47,22 @@ const ensureUsersDb = async () => {
       console.error('Error checking/creating users database:', err);
     }
   }
+
+  try {
+    await coursesDb.info();
+    console.log('Courses database exists and is accessible');
+  } catch (err) {
+    if (err.statusCode === 404) {
+      console.log('Creating courses database...');
+      await nanoInstance.db.create('courses');
+      console.log('Courses database created');
+    } else {
+      console.error('Error checking/creating courses database:', err);
+    }
+  }
 };
 
-// Call ensureUsersDb when the module loads
-ensureUsersDb();
+// Call ensureDbs when the module loads
+ensureDbs();
 
-module.exports = { nanoInstance, usersDb }; 
+module.exports = { nanoInstance, usersDb, coursesDb };

--- a/backend/index.js
+++ b/backend/index.js
@@ -5,6 +5,7 @@ try {
   const express = require('express');
   const cors = require('cors');
   const authRoutes = require('./routes/auth');
+  const courseRoutes = require('./routes/courses');
 
   const app = express();
 
@@ -12,6 +13,7 @@ try {
   app.use(express.json());
 
   app.use('/api/auth', authRoutes);
+  app.use('/api/courses', courseRoutes);
 
   const PORT = process.env.PORT || 5000;
   app.listen(PORT, () => {

--- a/backend/middleware/authorize.js
+++ b/backend/middleware/authorize.js
@@ -1,0 +1,8 @@
+module.exports = function (...roles) {
+  return (req, res, next) => {
+    if (!roles.includes(req.user.role)) {
+      return res.status(403).json({ message: 'Forbidden' });
+    }
+    next();
+  };
+};

--- a/backend/models/Course.js
+++ b/backend/models/Course.js
@@ -1,0 +1,32 @@
+const { coursesDb } = require('../db');
+
+class Course {
+  constructor(data) {
+    this.title = data.title;
+    this.description = data.description;
+    this.status = 'pending';
+    this.instructorId = data.instructorId;
+    this.type = 'course';
+    this.createdAt = new Date().toISOString();
+  }
+
+  static async create(data) {
+    const course = new Course(data);
+    const result = await coursesDb.insert(course);
+    return { _id: result.id, _rev: result.rev, ...course };
+  }
+
+  static async findByStatus(status) {
+    const result = await coursesDb.find({ selector: { status } });
+    return result.docs;
+  }
+
+  static async updateStatus(id, status) {
+    const doc = await coursesDb.get(id);
+    doc.status = status;
+    const result = await coursesDb.insert(doc);
+    return { _id: result.id, _rev: result.rev, ...doc };
+  }
+}
+
+module.exports = Course;

--- a/backend/routes/courses.js
+++ b/backend/routes/courses.js
@@ -1,0 +1,12 @@
+const express = require('express');
+const router = express.Router();
+const auth = require('../middleware/auth');
+const authorize = require('../middleware/authorize');
+const courseCtrl = require('../controllers/courseController');
+
+router.get('/', auth, courseCtrl.getApproved);
+router.post('/', auth, authorize('instructor'), courseCtrl.createCourse);
+router.get('/pending', auth, authorize('admin'), courseCtrl.getPending);
+router.put('/:id/approve', auth, authorize('admin'), courseCtrl.approve);
+
+module.exports = router;

--- a/client/.env.example
+++ b/client/.env.example
@@ -1,0 +1,3 @@
+VITE_COUCHDB_URL=http://localhost:5984
+VITE_COUCHDB_USER=prince
+VITE_COUCHDB_PASS=iranzi123

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,8 @@
         "bootstrap": "^5.3.6",
         "bootstrap-icons": "^1.13.1",
         "i18next": "^25.2.1",
+        "pouchdb-browser": "^8.0.1",
+        "pouchdb-find": "^8.0.1",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "react-i18next": "^15.5.2",
@@ -1727,6 +1729,18 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0"
       }
     },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.14.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.1.tgz",
@@ -1900,6 +1914,12 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
     "node_modules/callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -1968,6 +1988,15 @@
       "resolved": "https://registry.npmjs.org/classlist-polyfill/-/classlist-polyfill-1.2.0.tgz",
       "integrity": "sha512-GzIjNdcEtH4ieA2S8NmrSxv7DfEV5fmixQeyTmqmRmRJPGpRBaSnA2a0VrCjyT8iW8JjEdMbKzDotAJf+ajgaQ==",
       "license": "Unlicense"
+    },
+    "node_modules/clone-buffer": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/clone-buffer/-/clone-buffer-1.0.0.tgz",
+      "integrity": "sha512-KLLTJWrvwIP+OPfMn0x2PheDEP20RPUcGXj/ERegTgdmPEZylALQldygiqrPPu8P45uNuPs7ckmReLY6v/iA5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/color-convert": {
       "version": "2.0.1",
@@ -2321,6 +2350,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2355,6 +2393,18 @@
         "picomatch": {
           "optional": true
         }
+      }
+    },
+    "node_modules/fetch-cookie": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/fetch-cookie/-/fetch-cookie-0.11.0.tgz",
+      "integrity": "sha512-BQm7iZLFhMWFy5CZ/162sAGjBfdNWb7a8LEqqnzsHFhxT/X/SVj/z2t2nu3aJvjlbQkrAlTUApplPRjWyH4mhA==",
+      "license": "Unlicense",
+      "dependencies": {
+        "tough-cookie": "^2.3.3 || ^3.0.1 || ^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/file-entry-cache": {
@@ -2531,6 +2581,12 @@
       "engines": {
         "node": ">= 4"
       }
+    },
+    "node_modules/immediate": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.3.0.tgz",
+      "integrity": "sha512-HR7EVodfFUdQCTIeySw+WDRFJlPcLOJbXfwwZ7Oom6tjsvZ3bOkCDJHehQC3nxJrv7+f9XecwazynjU8e4Vw3Q==",
+      "license": "MIT"
     },
     "node_modules/immutable": {
       "version": "5.1.2",
@@ -2821,6 +2877,26 @@
       "license": "MIT",
       "optional": true
     },
+    "node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/node-releases": {
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
@@ -2960,6 +3036,131 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pouchdb-abstract-mapreduce": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-abstract-mapreduce/-/pouchdb-abstract-mapreduce-8.0.1.tgz",
+      "integrity": "sha512-BxJRHdfiC8gID8h4DPS0Xy6wsa2VBHRHMv9hsm0BhGTWTqS4k8ivItVSeU2dMoXiTBYp+7SerYmovUQNGSX1GA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "pouchdb-binary-utils": "8.0.1",
+        "pouchdb-collate": "8.0.1",
+        "pouchdb-collections": "8.0.1",
+        "pouchdb-errors": "8.0.1",
+        "pouchdb-fetch": "8.0.1",
+        "pouchdb-mapreduce-utils": "8.0.1",
+        "pouchdb-md5": "8.0.1",
+        "pouchdb-utils": "8.0.1"
+      }
+    },
+    "node_modules/pouchdb-binary-utils": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-binary-utils/-/pouchdb-binary-utils-8.0.1.tgz",
+      "integrity": "sha512-WsuR/S0aoUlcA0Alt99czkXsfuXWcrYXAcvGiTW02zawVXOafCnb/qHjA09TUaV0oy5HeHmYaNnDckoOUqspeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "buffer-from": "1.1.2"
+      }
+    },
+    "node_modules/pouchdb-browser": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-browser/-/pouchdb-browser-8.0.1.tgz",
+      "integrity": "sha512-wXObS1Layd/gBRKwa6EBS99tFY9G3VPaMRu8ffWCohkpi9PZCm3z1xeB4P4S9Qecf0u5so+rxvbVVyTtgdhvaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "immediate": "3.3.0",
+        "spark-md5": "3.0.2",
+        "uuid": "8.3.2",
+        "vuvuzela": "1.0.3"
+      }
+    },
+    "node_modules/pouchdb-collate": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-collate/-/pouchdb-collate-8.0.1.tgz",
+      "integrity": "sha512-DTuNz1UJjBTGZMUlWS1klSE1rPsmHy8IIDie3MFH1ZTz/C+SwGgGwkiAyUDv/n00D18EMLgXq5mu+r7L6K1BwQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/pouchdb-collections": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-collections/-/pouchdb-collections-8.0.1.tgz",
+      "integrity": "sha512-TlkQ2GGHJApJgL0b7bJMQcwX6eMfVenLeoK9mqHfC2fJssui+HWJJ5LYKHOWan11SeB90BQVFbO6rHN6CJQeDg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/pouchdb-errors": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-errors/-/pouchdb-errors-8.0.1.tgz",
+      "integrity": "sha512-H+ZsQxcG/JV3Tn29gnM6c9+lRPCN91ZYOkoIICsLjVRYgOTzN1AvNUD/G5JCB+81aI/u3fxZec0LEaZh6g6NHA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/pouchdb-fetch": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-fetch/-/pouchdb-fetch-8.0.1.tgz",
+      "integrity": "sha512-Px5HLT8MxqTujc8bpPRKoouznDTJa9XBGqCbhl95q6rhjWRfwZEvXjV92z0B5BALAM6D6avMyG0DjuNfUWnMuA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "abort-controller": "3.0.0",
+        "fetch-cookie": "0.11.0",
+        "node-fetch": "2.6.7"
+      }
+    },
+    "node_modules/pouchdb-find": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-find/-/pouchdb-find-8.0.1.tgz",
+      "integrity": "sha512-i5criYXMOXlbeRrCrXonqaOY+xiMiOyTLybqvtX/NkUsiD4BxJxkq5AxdSlHdJ9703nWJ0k6S+5C8VrpEj8tsQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "pouchdb-abstract-mapreduce": "8.0.1",
+        "pouchdb-collate": "8.0.1",
+        "pouchdb-errors": "8.0.1",
+        "pouchdb-fetch": "8.0.1",
+        "pouchdb-md5": "8.0.1",
+        "pouchdb-selector-core": "8.0.1",
+        "pouchdb-utils": "8.0.1"
+      }
+    },
+    "node_modules/pouchdb-mapreduce-utils": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-mapreduce-utils/-/pouchdb-mapreduce-utils-8.0.1.tgz",
+      "integrity": "sha512-asZcFLy1DA3oe5CeXIRCpfVrBHaHRvSb3Tc/LPD1dZDDtpEkeCuXGtJm+praN0jl41jTBEm0uMdD/YI0J5ZFXw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "pouchdb-collections": "8.0.1",
+        "pouchdb-utils": "8.0.1"
+      }
+    },
+    "node_modules/pouchdb-md5": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-md5/-/pouchdb-md5-8.0.1.tgz",
+      "integrity": "sha512-shVcs/K/iilrcAhDEERpLIrGm/cnDVsXiocOzs7kycJEuBqYnLD9nj58VwWDcum26wfa8T9cznvEGE1jlYVNPQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "pouchdb-binary-utils": "8.0.1",
+        "spark-md5": "3.0.2"
+      }
+    },
+    "node_modules/pouchdb-selector-core": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-selector-core/-/pouchdb-selector-core-8.0.1.tgz",
+      "integrity": "sha512-dHWsnR+mLGyfVld1vSHJI1xKTwS1xk1G2dggjfXfUrLehI+wysjTUOwiSNytyPzG6DpT+o86wyUpwzPwsDCLBw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "pouchdb-collate": "8.0.1",
+        "pouchdb-utils": "8.0.1"
+      }
+    },
+    "node_modules/pouchdb-utils": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/pouchdb-utils/-/pouchdb-utils-8.0.1.tgz",
+      "integrity": "sha512-pWgxdk9EHVWJmjQoEvTe+ZlPXyjcuQ/vgLITN+RjGwcYhoQYUE1M0PksQd2dUP3V8lGS4+wrg9lEM/qSJPYcpw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clone-buffer": "1.0.0",
+        "immediate": "3.3.0",
+        "pouchdb-collections": "8.0.1",
+        "pouchdb-errors": "8.0.1",
+        "pouchdb-md5": "8.0.1",
+        "uuid": "8.3.2"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -2970,15 +3171,32 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "license": "MIT"
     },
     "node_modules/react": {
       "version": "19.1.0",
@@ -3087,6 +3305,12 @@
         "type": "individual",
         "url": "https://paulmillr.com/funding/"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "license": "MIT"
     },
     "node_modules/resolve-from": {
       "version": "4.0.0",
@@ -3212,6 +3436,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/spark-md5": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/spark-md5/-/spark-md5-3.0.2.tgz",
+      "integrity": "sha512-wcFzz9cDfbuqe0FZzfi2or1sgyIrsDwmPwfZC4hiNidPdPINjeUwNfv5kldczoEAcjl9Y1L3SM7Uz2PUEQzxQw==",
+      "license": "(WTFPL OR MIT)"
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3268,6 +3498,27 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3279,6 +3530,15 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -3320,6 +3580,25 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/vite": {
@@ -3404,6 +3683,28 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/vuvuzela": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vuvuzela/-/vuvuzela-1.0.3.tgz",
+      "integrity": "sha512-Tm7jR1xTzBbPW+6y1tknKiEhz04Wf/1iZkcTJjSFcpNko43+dFW6+OOeQe9taJIug3NdfUAjFKgUSyQrIKaDvQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/which": {

--- a/client/package.json
+++ b/client/package.json
@@ -15,6 +15,8 @@
     "bootstrap": "^5.3.6",
     "bootstrap-icons": "^1.13.1",
     "i18next": "^25.2.1",
+    "pouchdb-browser": "^8.0.1",
+    "pouchdb-find": "^8.0.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-i18next": "^15.5.2",

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -4,6 +4,9 @@ import Home from './pages/Home'
 import Login from './pages/Login'
 import Signup from './pages/Signup'
 import ForgotPassword from './pages/ForgotPassword'
+import Dashboard from './pages/Dashboard'
+import InstructorUpload from './pages/InstructorUpload'
+import AdminReview from './pages/AdminReview'
 import './styles/main.scss'
 
 function App() {
@@ -15,6 +18,9 @@ function App() {
         <Route path="/login" element={<Login />} />
         <Route path="/signup" element={<Signup />} />
         <Route path="/forgot-password" element={<ForgotPassword />} />
+        <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/instructor" element={<InstructorUpload />} />
+        <Route path="/admin" element={<AdminReview />} />
         {/* Add more routes here as we create them */}
       </Routes>
     </Router>

--- a/client/src/hooks/useCourses.js
+++ b/client/src/hooks/useCourses.js
@@ -1,0 +1,25 @@
+import { useEffect, useState } from 'react';
+import { localCourses, syncCourses } from '../services/db';
+
+export default function useCourses(status = 'approved') {
+  const [courses, setCourses] = useState([]);
+
+  useEffect(() => {
+    const syncHandler = syncCourses();
+
+    const fetchCourses = async () => {
+      const result = await localCourses.find({ selector: { status } });
+      setCourses(result.docs);
+    };
+
+    fetchCourses();
+    localCourses.changes({ live: true, since: 'now', include_docs: true })
+      .on('change', fetchCourses);
+
+    return () => {
+      syncHandler.cancel();
+    };
+  }, [status]);
+
+  return courses;
+}

--- a/client/src/pages/AdminReview.jsx
+++ b/client/src/pages/AdminReview.jsx
@@ -1,0 +1,40 @@
+import { useEffect, useState } from 'react';
+
+export default function AdminReview() {
+  const [courses, setCourses] = useState([]);
+
+  useEffect(() => {
+    fetch('/api/courses/pending', {
+      headers: {
+        Authorization: 'Bearer ' + localStorage.getItem('token')
+      }
+    })
+      .then(res => res.json())
+      .then(setCourses);
+  }, []);
+
+  const approve = async id => {
+    await fetch(`/api/courses/${id}/approve`, {
+      method: 'PUT',
+      headers: { Authorization: 'Bearer ' + localStorage.getItem('token') }
+    });
+    setCourses(courses.filter(c => c._id !== id));
+  };
+
+  return (
+    <div className="container py-4">
+      <h2 className="mb-4">Pending Courses</h2>
+      <ul className="list-group">
+        {courses.map(c => (
+          <li key={c._id} className="list-group-item d-flex justify-content-between">
+            <div>
+              <h5>{c.title}</h5>
+              <p>{c.description}</p>
+            </div>
+            <button className="btn btn-success" onClick={() => approve(c._id)}>Approve</button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/client/src/pages/Dashboard.jsx
+++ b/client/src/pages/Dashboard.jsx
@@ -1,0 +1,19 @@
+import useCourses from '../hooks/useCourses';
+
+export default function Dashboard() {
+  const courses = useCourses();
+
+  return (
+    <div className="container py-4">
+      <h2 className="mb-4">Available Courses</h2>
+      <ul className="list-group">
+        {courses.map(c => (
+          <li key={c._id} className="list-group-item">
+            <h5>{c.title}</h5>
+            <p>{c.description}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/client/src/pages/InstructorUpload.jsx
+++ b/client/src/pages/InstructorUpload.jsx
@@ -1,0 +1,31 @@
+import { useState } from 'react';
+
+export default function InstructorUpload() {
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+
+  const submit = async e => {
+    e.preventDefault();
+    await fetch('/api/courses', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + localStorage.getItem('token')
+      },
+      body: JSON.stringify({ title, description })
+    });
+    setTitle('');
+    setDescription('');
+  };
+
+  return (
+    <div className="container py-4">
+      <h2 className="mb-4">Upload Course</h2>
+      <form onSubmit={submit} className="mb-3">
+        <input className="form-control mb-2" value={title} onChange={e => setTitle(e.target.value)} placeholder="Title" required />
+        <textarea className="form-control mb-2" value={description} onChange={e => setDescription(e.target.value)} placeholder="Description" required />
+        <button className="btn btn-primary" type="submit">Submit</button>
+      </form>
+    </div>
+  );
+}

--- a/client/src/pages/Login.jsx
+++ b/client/src/pages/Login.jsx
@@ -4,6 +4,24 @@ import { useTranslation } from 'react-i18next';
 
 const Login = () => {
   const { t } = useTranslation();
+  const submit = async e => {
+    e.preventDefault();
+    const email = e.target.elements['login-email'].value;
+    const password = e.target.elements['login-password'].value;
+    const res = await fetch('/api/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password })
+    });
+    const data = await res.json();
+    if (res.ok) {
+      localStorage.setItem('token', data.token);
+      localStorage.setItem('role', data.user.role);
+      window.location.href = '/dashboard';
+    } else {
+      alert(data.message || 'Login failed');
+    }
+  };
   return (
     <>
       <div className="auth-bg d-flex align-items-center justify-content-center min-vh-100" style={{background: 'linear-gradient(120deg, #e6f6fc 60%, #fafdff 100%)'}}>
@@ -11,7 +29,7 @@ const Login = () => {
           <div className="text-center mb-4">
             <h2 className="h4 mt-3 mb-2" style={{fontWeight: 700}}>{t('Log In')}</h2>
           </div>
-          <form autoComplete="off">
+          <form autoComplete="off" onSubmit={submit}>
             <div className="mb-3">
               <input type="email" className="form-control form-control-lg" id="login-email" placeholder={t('Email')} required />
             </div>

--- a/client/src/pages/Signup.jsx
+++ b/client/src/pages/Signup.jsx
@@ -4,6 +4,24 @@ import { useTranslation } from 'react-i18next';
 
 const Signup = () => {
   const { t } = useTranslation();
+  const submit = async e => {
+    e.preventDefault();
+    const email = e.target.elements['signup-email'].value;
+    const password = e.target.elements['signup-password'].value;
+    const role = e.target.elements['signup-role'].value;
+    const res = await fetch('/api/auth/register', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ email, password, role })
+    });
+    const data = await res.json();
+    if (res.ok) {
+      alert('Registered successfully');
+      window.location.href = '/login';
+    } else {
+      alert(data.message || 'Signup failed');
+    }
+  };
   return (
     <>
       <div className="auth-bg d-flex align-items-center justify-content-center min-vh-100" style={{background: 'linear-gradient(120deg, #e6f6fc 60%, #fafdff 100%)'}}>
@@ -11,7 +29,7 @@ const Signup = () => {
           <div className="text-center mb-4">
             <h2 className="h4 mt-3 mb-2" style={{fontWeight: 700}}>{t('Sign Up')}</h2>
           </div>
-          <form autoComplete="off">
+          <form autoComplete="off" onSubmit={submit}>
             <div className="mb-3">
               <input type="email" className="form-control form-control-lg" id="signup-email" placeholder={t('Email')} required />
             </div>

--- a/client/src/services/db.js
+++ b/client/src/services/db.js
@@ -1,0 +1,23 @@
+import PouchDB from 'pouchdb-browser';
+import PouchDBFind from 'pouchdb-find';
+
+PouchDB.plugin(PouchDBFind);
+
+const localCourses = new PouchDB('courses');
+
+const remoteUrl = import.meta.env.VITE_COUCHDB_URL || 'http://localhost:5984';
+const remoteCourses = new PouchDB(`${remoteUrl}/courses`, {
+  auth: {
+    username: import.meta.env.VITE_COUCHDB_USER || 'prince',
+    password: import.meta.env.VITE_COUCHDB_PASS || 'iranzi123'
+  }
+});
+
+export function syncCourses() {
+  return localCourses.sync(remoteCourses, {
+    live: true,
+    retry: true
+  });
+}
+
+export { localCourses };


### PR DESCRIPTION
## Summary
- add example `.env` files
- connect to `courses` DB in backend
- add course model, controller, routes and role middleware
- expose course APIs from server
- integrate PouchDB with live sync in React
- create dashboards for students, instructors and admin
- wire login and signup forms to backend

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` in `client` *(fails: ESLint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68432b2164448324a66d7b27e80fb538